### PR TITLE
Add support for version option; Make build option accepting empty string

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+### Description
+
+<!-- 
+    Provide an overview of what this pull request aims to address or achieve and describe the changes, including any technical details or architectural decisions.
+-->
+
+**Related task(s):**
+
+* [Productive Ticket](url-to-ticket)
+<!-- Link a relevant task(s) that this pull request addresses or resolves. -->
+
+### Additional notes
+
+<!-- 
+    Add any additional comments, instructions, or insights about this pull request. 
+-->
+
+### Design changes
+
+<!-- 
+    If this pull request includes any design changes, provide a brief overview and include relevant design files, screenshots and/or screen recordings.
+-->

--- a/app-deploy.sh
+++ b/app-deploy.sh
@@ -25,7 +25,7 @@ source /usr/local/bin/.app-deploy-sources/__build_tagging.sh
 # Use global variables at your own risk as this can be overridden in the future.
 set -e
 
-VERSION="2.0.0"
+VERSION="2.0.1"
 
 #################################
 #       START EVERYTHING        #

--- a/sources/__build_tagging.sh
+++ b/sources/__build_tagging.sh
@@ -71,8 +71,12 @@ function __validate_options {
         exit 1
     fi
 
-    # Check dependency between -p and -v
-    if [[ -z "$CUSTOM_APP_VERSION" && -z "$APP_PATH" ]]; then
+    # Ensure only one of -p or -v is set, and at least one is provided
+    if [[ -n "$APP_PATH" && -n "$CUSTOM_APP_VERSION" ]]; then
+        echo "Error: Options -p (path) and -v (version) are mutually exclusive. Provide only one."
+        echo "Usage: app-deploy tagging -e \"environment_name\" [-p \"path/to/app.{ipa/apk}\" | -v \"version\"] -b \"{build count}\""
+        exit 1
+    elif [[ -z "$APP_PATH" && -z "$CUSTOM_APP_VERSION" ]]; then
         echo "Error: Either -p (path) or -v (version) must be provided."
         echo "Usage: app-deploy tagging -e \"environment_name\" [-p \"path/to/app.{ipa/apk}\" | -v \"version\"] -b \"{build count}\""
         exit 1

--- a/sources/__build_tagging.sh
+++ b/sources/__build_tagging.sh
@@ -63,11 +63,25 @@ function __validate_options {
         esac
     done
 
-    # Check if all mandatory options are provided
-    if [[ -z "$ENVIRONMENT" || -z "$APP_PATH" || -z "$BUILD_COUNT" ]]; then
-        echo "Error: Missing mandatory options."
-        echo "Usage: app-deploy tagging -e \"environment_name\" -p \"path/to/app.{ipa/apk}\" -b \"{build count}\""
+    # Check if mandatory options are provided
+    if [[ -z "$ENVIRONMENT" ]]; then
+        echo "Error: Missing mandatory option -e (environment)."
+        echo "Usage: app-deploy tagging -e \"environment_name\" [-p \"path/to/app.{ipa/apk}\" | -v \"version\"] -b \"{build count}\""
         echo "Example: app-deploy tagging -e \"internal-staging\" -p \"path/to/app.ipa\" -b \"42\""
+        exit 1
+    fi
+
+    # Check dependency between -p and -v
+    if [[ -z "$CUSTOM_APP_VERSION" && -z "$APP_PATH" ]]; then
+        echo "Error: Either -p (path) or -v (version) must be provided."
+        echo "Usage: app-deploy tagging -e \"environment_name\" [-p \"path/to/app.{ipa/apk}\" | -v \"version\"] -b \"{build count}\""
+        exit 1
+    fi
+
+    # Ensure BUILD_COUNT is set (even if empty string is allowed)
+    if [[ ! -v BUILD_COUNT ]]; then
+        echo "Error: Missing mandatory option -b (build count)."
+        echo "Usage: app-deploy tagging -e \"environment_name\" [-p \"path/to/app.{ipa/apk}\" | -v \"version\"] -b \"{build count}\""
         exit 1
     fi
 }


### PR DESCRIPTION
This PR adds a new option -v. If we upload a .zip file (e.g., macOS/Windows app), we can not read that zip file and extract the app version. In that case, -v should be used.

### Usage
```bash
app-deploy tagging -e "internal-staging" -v "104" -b "$CI_COUNTER"
```

### Validations
To keep `-p` as a mandatory value, options validation is updated so that, only `-v` or `-p` can be used, but not both.
Additionally, to support skipping duplicated versions in the tag (e.g., `v1.2.3-100b100`), an empty string is now allowed on the -b option (i.e., `-b ""` is allowed). For now, we will keep `-b` option as mandatory.