### PR TITLE
Add -t and -m CLI flags to the trigger command

### DIFF
--- a/app-deploy.sh
+++ b/app-deploy.sh
@@ -12,8 +12,28 @@ if [ -z "$1" ] || [ "$1" == 'trigger' ] ; then
     [ "${args[0]}" == "trigger" ] && i=1 || i=0
     while [ $i -lt ${#args[@]} ]; do
         case "${args[$i]}" in
-            -m) i=$((i+1)); cli_changelog="${args[$i]}" ;;
-            -t) i=$((i+1)); cli_targets="${args[$i]}" ;;
+            -m)
+                next_index=$((i+1))
+                if [ $next_index -ge ${#args[@]} ] || [[ "${args[$next_index]}" == -* ]]; then
+                    echo
+                    echo "Missing value for -m flag. Please provide a changelog message after -m."
+                    echo
+                    exit 29
+                fi
+                i=$next_index
+                cli_changelog="${args[$i]}"
+                ;;
+            -t)
+                next_index=$((i+1))
+                if [ $next_index -ge ${#args[@]} ] || [[ "${args[$next_index]}" == -* ]]; then
+                    echo
+                    echo "Missing value for -t flag. Please provide target environments after -t."
+                    echo
+                    exit 29
+                fi
+                i=$next_index
+                cli_targets="${args[$i]}"
+                ;;
             *)
                 echo
                 echo "Unknown flag: ${args[$i]}"

--- a/app-deploy.sh
+++ b/app-deploy.sh
@@ -2,7 +2,28 @@
 
 source /usr/local/bin/.app-deploy-sources/__constants.sh
 source /usr/local/bin/.app-deploy-sources/__help.sh
+
+cli_changelog=""
+cli_targets=""
+
 if [ -z "$1" ] || [ "$1" == 'trigger' ] ; then
+    # Parse optional CLI flags for the trigger command
+    args=("$@")
+    [ "${args[0]}" == "trigger" ] && i=1 || i=0
+    while [ $i -lt ${#args[@]} ]; do
+        case "${args[$i]}" in
+            -m) i=$((i+1)); cli_changelog="${args[$i]}" ;;
+            -t) i=$((i+1)); cli_targets="${args[$i]}" ;;
+            *)
+                echo
+                echo "Unknown flag: ${args[$i]}"
+                echo
+                exit 29
+                ;;
+        esac
+        i=$((i+1))
+    done
+
     source ./.deploy-options.sh
     source /usr/local/bin/.app-deploy-sources/__trigger_deploy.sh
 fi

--- a/app-deploy.sh
+++ b/app-deploy.sh
@@ -3,47 +3,7 @@
 source /usr/local/bin/.app-deploy-sources/__constants.sh
 source /usr/local/bin/.app-deploy-sources/__help.sh
 
-cli_changelog=""
-cli_targets=""
-
 if [ -z "$1" ] || [ "$1" == 'trigger' ] ; then
-    # Parse optional CLI flags for the trigger command
-    args=("$@")
-    [ "${args[0]}" == "trigger" ] && i=1 || i=0
-    while [ $i -lt ${#args[@]} ]; do
-        case "${args[$i]}" in
-            -m)
-                next_index=$((i+1))
-                if [ $next_index -ge ${#args[@]} ] || [[ "${args[$next_index]}" == -* ]]; then
-                    echo
-                    echo "Missing value for -m flag. Please provide a changelog message after -m."
-                    echo
-                    exit 29
-                fi
-                i=$next_index
-                cli_changelog="${args[$i]}"
-                ;;
-            -t)
-                next_index=$((i+1))
-                if [ $next_index -ge ${#args[@]} ] || [[ "${args[$next_index]}" == -* ]]; then
-                    echo
-                    echo "Missing value for -t flag. Please provide target environments after -t."
-                    echo
-                    exit 29
-                fi
-                i=$next_index
-                cli_targets="${args[$i]}"
-                ;;
-            *)
-                echo
-                echo "Unknown flag: ${args[$i]}"
-                echo
-                exit 29
-                ;;
-        esac
-        i=$((i+1))
-    done
-
     source ./.deploy-options.sh
     source /usr/local/bin/.app-deploy-sources/__trigger_deploy.sh
 fi
@@ -66,7 +26,7 @@ source /usr/local/bin/.app-deploy-sources/__build_tagging.sh
 # Use global variables at your own risk as this can be overridden in the future.
 set -e
 
-VERSION="2.0.1"
+VERSION="2.1.0"
 
 #################################
 #       START EVERYTHING        #
@@ -84,7 +44,7 @@ elif [ "$1" == 'init' ] ; then
     __init
 elif [ -z "$1" ] || [ "$1" == 'trigger' ] ; then # Empty input or "trigger"
     __clear_console
-    __trigger_deploy
+    __trigger_deploy "$@"
 elif [ "$1" == 'environments' ] ; then
     __env_extractor "$2"
 elif [ "$1" == 'tagging' ]; then

--- a/sources/__help.sh
+++ b/sources/__help.sh
@@ -19,8 +19,8 @@ Parameters:
   init                      Initialize the deploy-options file for the project.
   trigger                   Generate a trigger tag for starting the CI/CD flow.
                             Accepts the following options:
-    -t <targets>            Specify build targets non-interactively (e.g., "0 1").
-    -m <changelog>          Specify the changelog message non-interactively.
+    -t <targets>            Specify build targets non-interactively (e.g., "0 1"). Should match deploy-options values.
+    -m <changelog>          Specify the changelog message non-interactively. Does not accept empty string "".
   environments <trigger-tag>
                             Extract environments from the specified trigger tag.
   tagging                   Generate a build tag after CI/CD uploads the build.

--- a/sources/__help.sh
+++ b/sources/__help.sh
@@ -20,7 +20,7 @@ Parameters:
   trigger                   Generate a trigger tag for starting the CI/CD flow.
                             Accepts the following options:
     -t <targets>            Specify build targets non-interactively (e.g., "0 1"). Should match deploy-options values.
-    -m <changelog>          Specify the changelog message non-interactively. Does not accept empty string "".
+    -m <changelog>          Specify the changelog message non-interactively.
   environments <trigger-tag>
                             Extract environments from the specified trigger tag.
   tagging                   Generate a build tag after CI/CD uploads the build.

--- a/sources/__help.sh
+++ b/sources/__help.sh
@@ -18,6 +18,9 @@ Parameters:
   --update                  Update the script to the latest version.
   init                      Initialize the deploy-options file for the project.
   trigger                   Generate a trigger tag for starting the CI/CD flow.
+                            Accepts the following options:
+    -t <targets>            Specify build targets non-interactively (e.g., "0 1").
+    -m <changelog>          Specify the changelog message non-interactively.
   environments <trigger-tag>
                             Extract environments from the specified trigger tag.
   tagging                   Generate a build tag after CI/CD uploads the build.
@@ -39,11 +42,15 @@ Examples:
       app-deploy or app-deploy trigger
       output: ci/internal-staging/2024-12-12T14-32
 
-  3. Extract environments from a trigger tag:
+  3. Generate a trigger tag (non-interactive):
+      app-deploy trigger -t "0 1" -m "Fixed login bug"
+      output: ci/internal-staging/internal-uat/2024-12-12T14-32
+
+  4. Extract environments from a trigger tag:
       app-deploy environments ci/internal-staging/2024-12-12T14-32
       output: internal-staging
 
-  4. Generate a final build tag:
+  5. Generate a final build tag:
       app-deploy tagging -e "internal-staging" -p "path/to/my-app.ipa" -b "123" -c "Added new features"
       output: internal-staging/v1.2.3-44b123
 

--- a/sources/__trigger_deploy.sh
+++ b/sources/__trigger_deploy.sh
@@ -16,16 +16,16 @@ bold=$(tput bold)
 normal=$(tput sgr0)
 
 function __parse_trigger_cli_flags {
-    cli_changelog=""
-    cli_targets=""
+    CLI_CHANGELOG=""
+    CLI_TARGETS=""
 
     [ "${1}" == "trigger" ] && shift
 
     while getopts "t:m:" opt; do
         case "$opt" in
-            t) cli_targets="$OPTARG" ;;
-            m) cli_changelog="$OPTARG" ;;
-            *) echo "Error: Invalid option"; exit 29 ;;
+            t) CLI_TARGETS="$OPTARG" ;;
+            m) CLI_CHANGELOG="$OPTARG" ;;
+            *) echo "Error: Invalid option"; exit 1 ;;
         esac
     done
 }
@@ -42,8 +42,8 @@ function __trigger_deploy {
 
     # CREATE TAG
 
-    if [ -n "$cli_targets" ]; then
-        deploy_options <<< "$cli_targets" # Get from .deploy-options.sh, setup per project
+    if [ -n "$CLI_TARGETS" ]; then
+        deploy_options <<< "$CLI_TARGETS" # Get from .deploy-options.sh, setup per project
     else
         deploy_options # Get from .deploy-options.sh, setup per project
     fi

--- a/sources/__trigger_deploy.sh
+++ b/sources/__trigger_deploy.sh
@@ -25,7 +25,11 @@ function __trigger_deploy {
 
     # CREATE TAG
 
-    deploy_options # Get from .deploy-options.sh, setup per project
+    if [ -n "$cli_targets" ]; then
+        deploy_options <<< "$cli_targets" # Get from .deploy-options.sh, setup per project
+    else
+        deploy_options # Get from .deploy-options.sh, setup per project
+    fi
     __input_to_tags
 
     if [ -z "$script_version" ] || [ "$script_version" == "v1" ]; then

--- a/sources/__trigger_deploy.sh
+++ b/sources/__trigger_deploy.sh
@@ -15,7 +15,24 @@ source /usr/local/bin/.app-deploy-sources/helpers/__initial_checkup.sh
 bold=$(tput bold)
 normal=$(tput sgr0)
 
+function __parse_trigger_cli_flags {
+    cli_changelog=""
+    cli_targets=""
+
+    [ "${1}" == "trigger" ] && shift
+
+    while getopts "t:m:" opt; do
+        case "$opt" in
+            t) cli_targets="$OPTARG" ;;
+            m) cli_changelog="$OPTARG" ;;
+            *) echo "Error: Invalid option"; exit 29 ;;
+        esac
+    done
+}
+
 function __trigger_deploy {
+
+    __parse_trigger_cli_flags "$@"
 
     __header_print
 

--- a/sources/helpers/__base_tag_handling.sh
+++ b/sources/helpers/__base_tag_handling.sh
@@ -114,7 +114,11 @@ function __generate_tag_and_changelog {
             CHANGELOG=`git show -s --format=%N ${TAG} | tail -n +4`
             git tag -a "$tag" -m "${CHANGELOG}"
         else
-            git tag -a "$tag"
+            if [ -n "$cli_changelog" ]; then
+                git tag -a "$tag" -m "$cli_changelog"
+            else
+                git tag -a "$tag"
+            fi
             tag_message_added=1
         fi
     done

--- a/sources/helpers/__base_tag_handling.sh
+++ b/sources/helpers/__base_tag_handling.sh
@@ -96,21 +96,23 @@ function __create_trigger_ci_timestamp_tag {
 # Changelog
 function __generate_tag_and_changelog {
 
-    echo
-    echo "###############################################################"
-    echo "#                          CHANGELOG                          #"
-    echo "###############################################################"
-    echo
-    echo "------------------------------------------------------------"
-    echo "Enter changelog message..."
-    echo "------------------------------------------------------------"
-    sleep 1
+    if [ -z "$CLI_CHANGELOG" ]; then
+        echo
+        echo "###############################################################"
+        echo "#                          CHANGELOG                          #"
+        echo "###############################################################"
+        echo
+        echo "------------------------------------------------------------"
+        echo "Enter changelog message..."
+        echo "------------------------------------------------------------"
+        sleep 1
+    fi
 
     tag_message_added=0
     for tag in "${tags_to_deploy[@]}"; do
 
-        if [ -n "$cli_changelog" ]; then
-            git tag -a "$tag" -m "$cli_changelog"
+        if [ -n "$CLI_CHANGELOG" ]; then
+            git tag -a "$tag" -m "$CLI_CHANGELOG"
         elif [ ${tag_message_added} -eq 1 ]; then
             TAG=`git describe --exact-match`
             CHANGELOG=`git show -s --format=%N ${TAG} | tail -n +4`

--- a/sources/helpers/__base_tag_handling.sh
+++ b/sources/helpers/__base_tag_handling.sh
@@ -109,16 +109,14 @@ function __generate_tag_and_changelog {
     tag_message_added=0
     for tag in "${tags_to_deploy[@]}"; do
 
-        if [ ${tag_message_added} -eq 1 ]; then
+        if [ -n "$cli_changelog" ]; then
+            git tag -a "$tag" -m "$cli_changelog"
+        elif [ ${tag_message_added} -eq 1 ]; then
             TAG=`git describe --exact-match`
             CHANGELOG=`git show -s --format=%N ${TAG} | tail -n +4`
             git tag -a "$tag" -m "${CHANGELOG}"
         else
-            if [ -n "$cli_changelog" ]; then
-                git tag -a "$tag" -m "$cli_changelog"
-            else
-                git tag -a "$tag"
-            fi
+            git tag -a "$tag"
             tag_message_added=1
         fi
     done


### PR DESCRIPTION
## Summary

- Adds `-t <targets>` flag to `trigger` command for non-interactive build target selection (e.g. `app-deploy trigger -t "0 1"`)
- Adds `-m <message>` flag to `trigger` command for non-interactive changelog input (e.g. `app-deploy trigger -m "Fixed login bug"`)
- Both flags can be combined for a fully non-interactive trigger: `app-deploy trigger -t "0" -m "Fixed login bug"`
- Unknown flags produce a clear error message and exit

## How it works

- Flag parsing happens in `app-deploy.sh` before any interactive prompts are reached
- When `-t` is set, `deploy_options` receives the targets via stdin here-string (`<<<`) so the `read` call is satisfied without blocking
- When `-m` is set, `git tag -a` uses `-m` directly instead of opening the editor
- Interactive mode is fully preserved when neither flag is provided