### PR TITLE
Fix: prefix install command with sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To successfully push tags to the repo, the local user and/or CI/CD project shoul
 To **install** this script, just run this command in Terminal from your <u>home directory</u>:
 
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/infinum/app-deploy-script/master/install.sh)"
+sudo /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/infinum/app-deploy-script/master/install.sh)"
 ```
 
 This script will install `app-deploy` and all the necessary components in `/usr/local/bin/`. 


### PR DESCRIPTION
## Summary

The installation command in the README is missing `sudo`, which causes it to fail with permission errors when trying to write files to `/usr/local/bin/`.

## Problem

Without `sudo`, the script fails because it lacks the necessary permissions to create files in `/usr/local/bin/`:

```
~  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/infinum/app-deploy-script/master/install.sh)"
  ==> This script will install:
  /usr/local/bin/app-deploy

  Do you want to proceed? [y/n] y

  Fetching script data...
  Installing...
  /bin/bash: line 44: /usr/local/bin/app-deploy: Permission denied
  mkdir: /usr/local/bin/.app-deploy-sources/: Permission denied
  cp: /usr/local/bin/.app-deploy-sources: Permission denied
  chmod: /usr/local/bin/app-deploy: No such file or directory
  chmod: /usr/local/bin/.app-deploy-sources/: No such file or directory
  Done!
```

## Fix

Prefix the install command with `sudo` so it runs with the required elevated permissions:

```bash
sudo /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/infinum/app-deploy-script/master/install.sh)"
```

Note: The README already mentions that `sudo` is needed ("Script commands such as `install`, and `--update` will need `sudo` to execute successfully."), but the example command itself did not reflect this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)